### PR TITLE
Have a default message in case vars are null valued

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -75,6 +75,8 @@ runs:
       run: |
         if [ ! -z "$PR_TITLE" ]; then
           echo "::set-output name=message::<$PR_URL|$PR_TITLE>"
+        else
+          echo "::set-output name=message::Image promotion for {{ inputs.target_environment }}"
         fi
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Github may not always have the event data associated with a release

```
##[debug]Evaluating: github.event.pull_request.html_url
##[debug]Evaluating Index:
##[debug]..Evaluating Index:
##[debug]....Evaluating Index:
##[debug]......Evaluating github:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'event'
##[debug]....=> Object
##[debug]....Evaluating String:
##[debug]....=> 'pull_request'
##[debug]..=> null
##[debug]=> null
##[debug]Result: null
##[debug]Evaluating: github.event.pull_request.title
##[debug]Evaluating Index:
##[debug]..Evaluating Index:
##[debug]....Evaluating Index:
##[debug]......Evaluating github:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'event'
##[debug]....=> Object
##[debug]....Evaluating String:
##[debug]....=> 'pull_request'
##[debug]..=> null
##[debug]=> null
##[debug]Result: null
```